### PR TITLE
Add pad token fallback and disable cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ After the environment is ready, launch training with the example script
 accelerate launch --config_file fsdp_single_gpu.yaml finetune_qwen_fsdp.py --output_dir ./qwen-output
 ```
 
+The trainer will automatically set the tokenizer's `pad_token` to the `eos_token` if the former is missing.
+
 See `instruction.md` for a complete walkthrough and more details on dataset preparation.
 
 ## Sanity Check

--- a/diloco_fsdp_framework.py
+++ b/diloco_fsdp_framework.py
@@ -61,6 +61,8 @@ class DilocoFSDPTrainer:
         self.tokenizer = AutoTokenizer.from_pretrained(
             config.model_name, use_fast=False, trust_remote_code=True
         )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
         self.model = AutoModelForCausalLM.from_pretrained(
             config.model_name,
             torch_dtype=torch.bfloat16
@@ -68,6 +70,7 @@ class DilocoFSDPTrainer:
             else torch.float16,
             trust_remote_code=True,
         )
+        self.model.config.use_cache = False
         self.model.gradient_checkpointing_enable()
 
         # --- Dataset streaming ---

--- a/instruction.md
+++ b/instruction.md
@@ -68,6 +68,8 @@ from transformers import AutoTokenizer
 tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-0.5B")
 ```
 
+If the tokenizer lacks a padding token, the training framework will automatically set `tokenizer.pad_token` to the end-of-sequence token.
+
 Qwen’s tokenizer has a large vocabulary (\~152k tokens), covering multiple languages and code. We should decide on a maximum sequence length for training (for example, 512 or 1024 tokens) to balance memory and the ability to capture long contexts. The Qwen model supports up to 16k or more tokens context, but a 3090 GPU may not handle very long sequences in training, so we might choose 1024 for fine-tuning.
 
 There are two approaches to prepare batches:


### PR DESCRIPTION
## Summary
- auto assign `tokenizer.pad_token` when missing
- disable `use_cache` after model instantiation
- mention the pad token handling in README and instructions

## Testing
- `python -m py_compile diloco_fsdp_framework.py finetune_qwen_fsdp.py finetune_qwen3_fsdp.py finetune_qwen3_mvp.py sanity_check_framework.py`