### PR TITLE
Enable per-node FSDP groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ accelerate launch --config_file fsdp_single_gpu.yaml finetune_qwen_fsdp.py --out
 
 See `instruction.md` for a complete walkthrough and more details on dataset preparation.
 
+### Multi-Node Launch
+
+When running on multiple machines, start the script on each node with its
+`machine_rank` and the total number of nodes. The trainer builds a per-node
+process group so that FSDP shards only among GPUs on the same host.
+
+```bash
+# node 0
+accelerate launch --num_machines 2 --machine_rank 0 \
+    --config_file fsdp_multi_gpu.yaml finetune_qwen_fsdp.py --output_dir /path/to/out
+
+# node 1
+accelerate launch --num_machines 2 --machine_rank 1 \
+    --config_file fsdp_multi_gpu.yaml finetune_qwen_fsdp.py --output_dir /path/to/out
+```
+
+`fsdp_multi_gpu.yaml` should describe the GPU layout for a single node (e.g. 4
+processes) and the address of node 0. With this setup, model shards are kept
+local to each node while gradients for the outer loop are synchronized across
+all nodes.
+
 ## Sanity Check
 
 To verify that your environment and dependencies are working, you can run a very

--- a/diloco_fsdp_framework.py
+++ b/diloco_fsdp_framework.py
@@ -22,8 +22,10 @@ from torch.optim import AdamW, SGD
 from torch.utils.data import DataLoader
 from torch.distributed import barrier
 from torch.distributed.device_mesh import DeviceMesh
+import torch.distributed as dist
 from transformers import AutoTokenizer, AutoModelForCausalLM, get_scheduler
 from accelerate import Accelerator
+from accelerate.utils import FullyShardedDataParallelPlugin
 from tqdm.auto import tqdm
 
 
@@ -51,11 +53,30 @@ class DilocoFSDPTrainer:
 
     def __init__(self, config: TrainerConfig, accelerator: Optional[Accelerator] = None):
         self.config = config
-        self.accelerator = accelerator or Accelerator(
-            gradient_accumulation_steps=config.grad_accum
-        )
+
+        if accelerator is None:
+            self._fsdp_plugin = FullyShardedDataParallelPlugin()
+            self.accelerator = Accelerator(
+                gradient_accumulation_steps=config.grad_accum,
+                fsdp_plugin=self._fsdp_plugin,
+            )
+        else:
+            self.accelerator = accelerator
+            self._fsdp_plugin = getattr(self.accelerator.state, "fsdp_plugin", None)
+
         self.device = self.accelerator.device
         self.is_main = self.accelerator.is_main_process
+
+        # Create a per-node process group so FSDP only shards within each node
+        self.fsdp_process_group = None
+        if self.accelerator.num_processes > 1 and dist.is_initialized():
+            local_world = int(os.environ.get("LOCAL_WORLD_SIZE", self.accelerator.num_processes))
+            rank = dist.get_rank()
+            start = (rank // local_world) * local_world
+            ranks = list(range(start, start + local_world))
+            self.fsdp_process_group = dist.new_group(ranks=ranks)
+            if self._fsdp_plugin is not None:
+                self._fsdp_plugin.fsdp_process_group = self.fsdp_process_group
 
         # --- Tokenizer & model ---
         self.tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
## Summary
- configure the FSDP plugin with a per-node process group
- document how to launch multi-node runs

## Testing
- `python -m py_compile diloco_fsdp_framework.py`
- `python -m py_compile finetune_qwen_fsdp.py finetune_qwen3_fsdp.py sanity_check_framework.py`
