### PR TITLE
Add benchmarking and eval to sanity check script

### DIFF
--- a/sanity_check_framework.py
+++ b/sanity_check_framework.py
@@ -2,6 +2,8 @@
 """Quick sanity check for the DilocoFSDPTrainer."""
 
 import argparse
+import math
+import time
 
 from diloco_fsdp_framework import DilocoFSDPTrainer, TrainerConfig
 
@@ -17,7 +19,34 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seq_len", type=int, default=16)
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--steps", type=int, default=1)
+    parser.add_argument(
+        "--eval_batches",
+        type=int,
+        default=0,
+        help="Number of batches to run for evaluation after training",
+    )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Print training throughput information",
+    )
     return parser.parse_args()
+
+
+def evaluate(trainer: DilocoFSDPTrainer, num_batches: int) -> None:
+    """Run a few batches in eval mode and print perplexity."""
+    trainer.model.eval()
+    losses = []
+    for i, batch in enumerate(trainer.dataloader):
+        if i >= num_batches:
+            break
+        with torch.no_grad():
+            outputs = trainer.model(**batch)
+            losses.append(outputs.loss.item())
+    trainer.model.train()
+    if losses:
+        ppl = math.exp(sum(losses) / len(losses))
+        print(f"\nEval perplexity over {num_batches} batches: {ppl:.2f}")
 
 
 def main() -> None:
@@ -35,7 +64,15 @@ def main() -> None:
         diloco_loops=1,
     )
     trainer = DilocoFSDPTrainer(cfg)
+    start = time.time()
     trainer.train()
+    end = time.time()
+    if args.benchmark:
+        tokens = args.seq_len * args.batch_size * args.steps
+        throughput = tokens / (end - start)
+        print(f"\nTrained {tokens} tokens in {end - start:.2f}s ({throughput:.2f} tokens/s)")
+    if args.eval_batches > 0:
+        evaluate(trainer, args.eval_batches)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend sanity_check_framework with benchmarking and evaluation
- keep trainer run but optionally print throughput and perplexity

## Testing
- `PYTHONPATH=. pytest -q`