### PR TITLE
Add checkpoint support to Diloco FSDP trainer

### DIFF
--- a/finetune_qwen_fsdp.py
+++ b/finetune_qwen_fsdp.py
@@ -42,6 +42,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Dataset field containing the text (defaults to auto-detect)",
     )
+    parser.add_argument(
+        "--checkpoint_steps",
+        type=int,
+        default=0,
+        help="Save a checkpoint every N steps (0 disables)",
+    )
+    parser.add_argument(
+        "--resume_checkpoint",
+        default=None,
+        help="Path to a checkpoint to resume from",
+    )
     return parser.parse_args()
 
 
@@ -61,6 +72,8 @@ def main() -> None:
         outer_lr=args.outer_lr,
         outer_momentum=args.outer_momentum,
         text_field=args.text_field,
+        checkpoint_steps=args.checkpoint_steps,
+        resume_from=args.resume_checkpoint,
     )
     trainer = DilocoFSDPTrainer(cfg)
     trainer.train()

--- a/tests/test_diloco_fsdp_framework.py
+++ b/tests/test_diloco_fsdp_framework.py
@@ -226,3 +226,37 @@ def test_init_compressed_prev_vector(monkeypatch):
     cfg = df.TrainerConfig('m', 'd', 's', 'out', max_steps=1)
     trainer = df.DilocoFSDPTrainer(cfg, accelerator=dummy_acc)
     assert trainer.prev_vector.dtype == torch.float16
+
+
+def test_checkpoint_save_load(tmp_path):
+    trainer = make_trainer(df.TrainerConfig('m', 'n', 's', 'o'))
+    trainer.accelerator = DummyAccelerator()
+    trainer.accelerator.get_state_dict = lambda m: m.state_dict()
+    trainer.accelerator.unwrap_model = lambda m: m
+    trainer.is_main = True
+    trainer.model = torch.nn.Linear(1, 1)
+    trainer.optimizer = torch.optim.AdamW(trainer.model.parameters())
+    trainer.outer_optimizer = torch.optim.SGD(trainer.model.parameters(), lr=0.1)
+    trainer.momentum_buffer = torch.tensor([1.0])
+    orig_params = [p.detach().clone() for p in trainer.model.parameters()]
+    orig_inner = trainer.optimizer.state_dict()
+    orig_outer = trainer.outer_optimizer.state_dict()
+    orig_mb = trainer.momentum_buffer.clone()
+
+    ckpt = tmp_path / 'ckpt.pt'
+    df.DilocoFSDPTrainer.save_checkpoint(trainer, ckpt, step=5)
+    assert ckpt.exists()
+
+    for p in trainer.model.parameters():
+        p.data.add_(1)
+    trainer.optimizer.param_groups[0]['lr'] = 2.0
+    trainer.outer_optimizer.param_groups[0]['lr'] = 3.0
+    trainer.momentum_buffer.add_(2)
+
+    step = df.DilocoFSDPTrainer.load_checkpoint(trainer, ckpt)
+    assert step == 5
+    for p, o in zip(trainer.model.parameters(), orig_params):
+        assert torch.equal(p, o)
+    assert trainer.optimizer.state_dict()['param_groups'][0]['lr'] == orig_inner['param_groups'][0]['lr']
+    assert trainer.outer_optimizer.state_dict()['param_groups'][0]['lr'] == orig_outer['param_groups'][0]['lr']
+    assert torch.equal(trainer.momentum_buffer, orig_mb)


### PR DESCRIPTION
## Summary
- introduce checkpoint saving/loading in `DilocoFSDPTrainer`
- save checkpoints every `checkpoint_steps` and allow resuming
- expose new CLI flags in `finetune_qwen_fsdp.py`
- test checkpoint round‑trip

## Testing
- `PYTHONPATH=. pytest -q`