### PR TITLE
Handle NaN loss in sanity check eval

### DIFF
--- a/sanity_check_framework.py
+++ b/sanity_check_framework.py
@@ -35,23 +35,40 @@ def parse_args() -> argparse.Namespace:
 
 
 def evaluate(trainer: DilocoFSDPTrainer, num_batches: int) -> None:
-    """Run a few batches in eval mode and print perplexity."""
+    """Run a few batches in eval mode and print perplexity.
+
+    A fresh dataloader is constructed so evaluation starts from the beginning of
+    the streaming dataset. Any non-finite losses are skipped. If no valid losses
+    are found, a warning is printed instead of raising an error.
+    """
     trainer.model.eval()
-    losses = []
-    for i, batch in enumerate(trainer.dataloader):
+
+    eval_loader = DataLoader(
+        trainer.raw_dataset,
+        batch_size=trainer.config.batch_size,
+        num_workers=trainer.config.num_workers,
+        collate_fn=trainer.collate_fn,
+    )
+
+    losses: list[float] = []
+    for i, batch in enumerate(eval_loader):
         if i >= num_batches:
             break
         with torch.no_grad():
             outputs = trainer.model(**batch)
-            losses.append(outputs.loss.item())
+            loss = outputs.loss.item()
+            if math.isfinite(loss):
+                losses.append(loss)
+
     trainer.model.train()
-    if losses:
-        mean_loss = sum(losses) / len(losses)
-        if math.isfinite(mean_loss):
-            ppl = math.exp(mean_loss)
-            print(f"\nEval perplexity over {num_batches} batches: {ppl:.2f}")
-        else:
-            print("\nEval produced NaN/Inf loss.")
+
+    if not losses:
+        print("\nEval produced NaN/Inf loss.")
+        return
+
+    mean_loss = sum(losses) / len(losses)
+    ppl = math.exp(mean_loss)
+    print(f"\nEval perplexity over {len(losses)} batches: {ppl:.2f}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- skip non-finite losses when running `sanity_check_framework.py`
- warn if all eval losses are NaN/Inf
- reinitialize dataloader for evaluation

## Testing
- `PYTHONPATH=. pytest -q`