### PR TITLE
Add DTensor sanity check

### DIFF
--- a/sanity_check_dtensor.py
+++ b/sanity_check_dtensor.py
@@ -1,0 +1,37 @@
+"""Run a quick check that OuterOptimizer handles DTensor shapes correctly."""
+
+import types
+import torch
+from outer_optimizer import OuterOptimizer
+
+
+def main() -> None:
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2, 2))
+
+    model = DummyModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    local = model.weight.data
+    global_shape = torch.Size([4, 2])
+    model.weight.to_local = lambda: local
+    model.weight.device_mesh = types.SimpleNamespace(get_group=lambda: None)
+    model.weight.placements = (torch.distributed.tensor.Shard(0),)
+    model.weight.numel = lambda: global_shape.numel()
+
+    outer = OuterOptimizer(model, opt, device=torch.device("cpu"), device_mesh=None)
+
+    with torch.no_grad():
+        model.weight.add_(1.0)
+    delta_norm = outer.step()
+
+    print("prev_vector elements:", outer.prev_vector.numel())
+    print("grad_param shape:", outer.grad_params[0].shape)
+    print("weight.grad shape:", model.weight.grad.shape)
+    print("delta_norm:", delta_norm)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dtensor_sanity.py
+++ b/tests/test_dtensor_sanity.py
@@ -1,0 +1,31 @@
+import types
+import torch
+from outer_optimizer import OuterOptimizer
+
+
+def test_outer_optimizer_handles_dtensor_local_size():
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2, 2))
+
+    model = DummyModel()
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    local = model.weight.data
+    global_shape = torch.Size([4, 2])
+    model.weight.to_local = lambda: local
+    model.weight.device_mesh = types.SimpleNamespace(get_group=lambda: None)
+    model.weight.placements = (torch.distributed.tensor.Shard(0),)
+    model.weight.numel = lambda: global_shape.numel()
+
+    outer = OuterOptimizer(model, opt, device=torch.device('cpu'), device_mesh=None)
+
+    with torch.no_grad():
+        model.weight.add_(1.0)
+    delta_norm = outer.step()
+
+    assert outer.prev_vector.numel() == local.numel()
+    assert outer.grad_params[0].shape == local.shape
+    assert model.weight.grad.shape == local.shape
+    assert delta_norm > 0


### PR DESCRIPTION
## Summary
- handle DTensor local shape when allocating grad buffers and slicing deltas
- keep gradients after `OuterOptimizer.step`
- add `sanity_check_dtensor.py` example
- test DTensor handling with a dummy sharded parameter

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b9f08ded4832e9b55f3c2e8e01f56